### PR TITLE
Removed HomePage and LandingPage Imports inside src/index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ import { NotFoundPage } from './components/pages/NotFound';
 import { ExampleListPage } from './components/pages/ExampleList';
 import { ProfileListPage } from './components/pages/ProfileList';
 import { LoginPage } from './components/pages/Login';
-import { HomePage } from './components/pages/Home';
 import { LandingPage } from './components/pages/Landing';
 import { ExampleDataViz } from './components/pages/ExampleDataViz';
 import { config } from './utils/oktaConfig';

--- a/src/index.js
+++ b/src/index.js
@@ -14,7 +14,6 @@ import { NotFoundPage } from './components/pages/NotFound';
 import { ExampleListPage } from './components/pages/ExampleList';
 import { ProfileListPage } from './components/pages/ProfileList';
 import { LoginPage } from './components/pages/Login';
-import { LandingPage } from './components/pages/Landing';
 import { ExampleDataViz } from './components/pages/ExampleDataViz';
 import { config } from './utils/oktaConfig';
 import { LoadingComponent } from './components/common';


### PR DESCRIPTION
Since the Home and Landing components were removed as they were not part of the design and scope of the current project, we also needed to remove their imports inside src/index.js.

What work was done? 
- I went into src/index.js and deleted the following imports:
1. import { HomePage } from './components/pages/Home';
2. import { LandingPage } from './components/pages/Landing';