### PR TITLE
Feature/restyling case details forms

### DIFF
--- a/src/components/common/CaseDetails/CaseDetails.js
+++ b/src/components/common/CaseDetails/CaseDetails.js
@@ -9,6 +9,10 @@ import arrow from '../../../assets/VectorarrowForAllCases.png';
 import filter from '../../../assets/filterIcon.PNG';
 import SearchIcon from './SearchIcon';
 
+//Component imports
+import ClientFamilyInfoForm from '../CaseDetailsForms/ClientFamilyInformation';
+import HouseholdInformationForm from '../CaseDetailsForms/HouseholdInformationForm';
+
 //AntD special component peices
 const { Panel } = Collapse;
 const { TextArea } = Input;
@@ -88,10 +92,10 @@ function CaseDetails() {
         <div className="CaseDetails__LeftSideBtnsContainer">
           <Collapse accordion className="mainCollapse">
             <Panel header="CLIENT/FAMILY INFORMATION" key="1" showArrow={false}>
-              <p>When form is built, we can add it here</p>
+              <ClientFamilyInfoForm />
             </Panel>
             <Panel header="HOUSEHOLD INFORMATION" key="2" showArrow={false}>
-              <p>When form is built, we can add it here</p>
+              <HouseholdInformationForm />
             </Panel>
             <Panel header="EDUCATION" key="3" showArrow={false}>
               <p>When form is built, we can add it here</p>

--- a/src/components/common/CaseDetailsForms/ClientFamilyInformation.js
+++ b/src/components/common/CaseDetailsForms/ClientFamilyInformation.js
@@ -245,30 +245,33 @@ const ClientFamilyInfoForm = () => {
             </Form.Item>
           </section>
           <section className="ClientFamilyInformation__Form__SectionGrid3">
-            <Form.Item
-              label={
-                <label className="ClientFamilyInformation__Inputs__ItemLabel__Small">
-                  City:
-                </label>
-              }
-            >
-              <Input
-                placeholder="City Name"
-                className="ClientFamilyInformation__Form__Inputs"
-              />
-            </Form.Item>
-            <Form.Item
-              label={
-                <label className="ClientFamilyInformation__Inputs__ItemLabel__Small">
-                  State:
-                </label>
-              }
-            >
-              <Input
-                placeholder="State Abbrv."
-                className="ClientFamilyInformation__Form__SmallInputs"
-              />
-            </Form.Item>
+            <div className="CityandState__Container">
+              <Form.Item
+                label={
+                  <label className="ClientFamilyInformation__Inputs__ItemLabel__Small">
+                    City:
+                  </label>
+                }
+              >
+                <Input
+                  placeholder="City Name"
+                  className="ClientFamilyInformation__Form__Inputs"
+                />
+              </Form.Item>
+              <Form.Item
+                label={
+                  <label className="ClientFamilyInformation__Inputs__ItemLabel__Small StateMargin">
+                    State:
+                  </label>
+                }
+              >
+                <Input
+                  placeholder="State Abbrv."
+                  className="ClientFamilyInformation__Form__SmallInputs StateMargin"
+                  style={{ width: 335 }}
+                />
+              </Form.Item>
+            </div>
             <Form.Item
               label={
                 <label className="ClientFamilyInformation__Inputs__ItemLabel__Small">
@@ -342,18 +345,20 @@ const ClientFamilyInfoForm = () => {
                 <DatePicker placeholder="MM-DD-YYYY" format={dateFormat} />
               </Form.Item>
             </div>
-            <Form.Item
-              label={
-                <label className="ClientFamilyInformation__Inputs__ItemLabel">
-                  Which Family Member?
-                </label>
-              }
-            >
-              <Input
-                className="ClientFamilyInformation__Form__Inputs"
-                placeholder="Spouse, Domestic Partner, Child, Etc..."
-              />
-            </Form.Item>
+            <div className="pregnantFamilyMember__Container">
+              <Form.Item
+                label={
+                  <label className="ClientFamilyInformation__Inputs__ItemLabel">
+                    Which Family Member?
+                  </label>
+                }
+              >
+                <Input
+                  className="ClientFamilyInformation__Form__Inputs"
+                  placeholder="Spouse, Domestic Partner, Child, Etc..."
+                />
+              </Form.Item>
+            </div>
           </section>
         </div>
       </Form>

--- a/src/components/common/CaseDetailsForms/ClientFamilyInformation.js
+++ b/src/components/common/CaseDetailsForms/ClientFamilyInformation.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import {
   Form,
   Select,
@@ -31,6 +31,21 @@ const initialFormValues = {
 
 const ClientFamilyInfoForm = () => {
   const [form] = Form.useForm();
+  const [disabled, setDisabled] = useState(true);
+
+  const onFinish = values => {
+    const updatedHousehold = values;
+    console.log(updatedHousehold);
+    setDisabled(!disabled);
+  };
+
+  const onFinishFailed = errorInfo => {
+    console.log('Failed:', errorInfo);
+  };
+
+  const disableFormItem = () => {
+    setDisabled(!disabled);
+  };
 
   const dateFormat = 'MM/DD/YYYY';
 
@@ -39,6 +54,8 @@ const ClientFamilyInfoForm = () => {
       <Form
         form={form}
         className="ClientFamilyInformation__Form"
+        onFinish={onFinish}
+        onFinishFailed={onFinishFailed}
         initialValues={initialFormValues}
         layout="vertical"
         labelCol={{ span: 8 }}
@@ -53,7 +70,11 @@ const ClientFamilyInfoForm = () => {
             </label>
           }
         >
-          <DatePicker placeholder="MM-DD-YYYY" format={dateFormat} />
+          <DatePicker
+            placeholder="MM-DD-YYYY"
+            format={dateFormat}
+            disabled={disabled}
+          />
         </Form.Item>
         <h1 className="ClientFamilyInformation__Form__h1">Head of Household</h1>
         <div className="ClientFamilyInformation__Form__SectionGrid2">
@@ -68,6 +89,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="First Name"
                 className="ClientFamilyInformation__Form__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
             <Form.Item
@@ -81,6 +103,7 @@ const ClientFamilyInfoForm = () => {
                 placeholder="XXX - XXX - XXXX"
                 className="ClientFamilyInformation__Form__Inputs"
                 name="SSN"
+                disabled={disabled}
               />
             </Form.Item>
             <Form.Item
@@ -93,6 +116,7 @@ const ClientFamilyInfoForm = () => {
               <Select
                 className="ClientFamilyInformation__Form__Inputs"
                 placeholder="-- Select --"
+                disabled={disabled}
               >
                 <Select.Option value="American Indian or Alaska Native" />
                 <Select.Option value="Asian" />
@@ -114,6 +138,7 @@ const ClientFamilyInfoForm = () => {
               <Select
                 className="ClientFamilyInformation__Form__Inputs"
                 placeholder="-- Select --"
+                disabled={disabled}
               >
                 <Select.Option value="Male" />
                 <Select.Option value="Female" />
@@ -133,6 +158,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="Self Describe"
                 className="ClientFamilyInformation__Form__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
           </section>
@@ -147,6 +173,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="Last Name"
                 className="ClientFamilyInformation__Form__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
             <Form.Item
@@ -156,7 +183,11 @@ const ClientFamilyInfoForm = () => {
                 </label>
               }
             >
-              <DatePicker placeholder="MM-DD-YYYY" format={dateFormat} />
+              <DatePicker
+                placeholder="MM-DD-YYYY"
+                format={dateFormat}
+                disabled={disabled}
+              />
             </Form.Item>
             <Form.Item
               label={
@@ -168,6 +199,7 @@ const ClientFamilyInfoForm = () => {
               <Select
                 className="ClientFamilyInformation__Form__Inputs"
                 placeholder="-- Select --"
+                disabled={disabled}
               >
                 <Select.Option value="American Indian or Alaska Native" />
                 <Select.Option value="Asian" />
@@ -186,6 +218,7 @@ const ClientFamilyInfoForm = () => {
               <Select
                 className="ClientFamilyInformation__Form__Inputs"
                 placeholder="-- Select --"
+                disabled={disabled}
               >
                 <Select.Option value="Asexual" />
                 <Select.Option value="Bisexual" />
@@ -209,6 +242,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="Other"
                 className="ClientFamilyInformation__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
           </section>
@@ -229,6 +263,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="Address"
                 className="ClientFamilyInformation__Form__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
             <Form.Item
@@ -241,6 +276,7 @@ const ClientFamilyInfoForm = () => {
               <Input
                 placeholder="Apt #"
                 className="ClientFamilyInformation__Form__Inputs"
+                disabled={disabled}
               />
             </Form.Item>
           </section>
@@ -256,6 +292,7 @@ const ClientFamilyInfoForm = () => {
                 <Input
                   placeholder="City Name"
                   className="ClientFamilyInformation__Form__Inputs"
+                  disabled={disabled}
                 />
               </Form.Item>
               <Form.Item
@@ -269,6 +306,7 @@ const ClientFamilyInfoForm = () => {
                   placeholder="State Abbrv."
                   className="ClientFamilyInformation__Form__SmallInputs StateMargin"
                   style={{ width: 335 }}
+                  disabled={disabled}
                 />
               </Form.Item>
             </div>
@@ -282,6 +320,7 @@ const ClientFamilyInfoForm = () => {
               <InputNumber
                 placeholder="Zip Code"
                 className="ClientFamilyInformation__Form__SmallInputs"
+                disabled={disabled}
               />
             </Form.Item>
           </section>
@@ -294,8 +333,12 @@ const ClientFamilyInfoForm = () => {
               }
             >
               <Radio.Group>
-                <Radio value={1}>Yes</Radio>
-                <Radio value={2}>No</Radio>
+                <Radio value={1} disabled={disabled}>
+                  Yes
+                </Radio>
+                <Radio value={2} disabled={disabled}>
+                  No
+                </Radio>
               </Radio.Group>
             </Form.Item>
           </section>
@@ -313,6 +356,7 @@ const ClientFamilyInfoForm = () => {
                 borderColor: '#007FD4',
               }}
               type="primary"
+              disabled={disabled}
             >
               + Add Member
             </Button>
@@ -330,8 +374,12 @@ const ClientFamilyInfoForm = () => {
                 }
               >
                 <Radio.Group>
-                  <Radio value={1}>Yes</Radio>
-                  <Radio value={2}>No</Radio>
+                  <Radio value={1} disabled={disabled}>
+                    Yes
+                  </Radio>
+                  <Radio value={2} disabled={disabled}>
+                    No
+                  </Radio>
                 </Radio.Group>
               </Form.Item>
               <Form.Item
@@ -342,7 +390,11 @@ const ClientFamilyInfoForm = () => {
                   </label>
                 }
               >
-                <DatePicker placeholder="MM-DD-YYYY" format={dateFormat} />
+                <DatePicker
+                  placeholder="MM-DD-YYYY"
+                  format={dateFormat}
+                  disabled={disabled}
+                />
               </Form.Item>
             </div>
             <div className="pregnantFamilyMember__Container">
@@ -356,8 +408,38 @@ const ClientFamilyInfoForm = () => {
                 <Input
                   className="ClientFamilyInformation__Form__Inputs"
                   placeholder="Spouse, Domestic Partner, Child, Etc..."
+                  disabled={disabled}
                 />
               </Form.Item>
+            </div>
+          </section>
+          <section>
+            <div className="editButtonsContainer">
+              <Button
+                htmlType="submit"
+                disabled={disabled}
+                style={{
+                  margin: '1rem',
+                  color: '#CDCDCD',
+                  background: '#007FD4',
+                  borderWidth: '3px',
+                }}
+                type="primary"
+              >
+                SAVE
+              </Button>
+              <Button
+                onClick={disableFormItem}
+                style={{
+                  margin: '1rem',
+                  color: '#CDCDCD',
+                  background: '#007FD4',
+                  borderWidth: '3px',
+                }}
+                type="primary"
+              >
+                EDIT
+              </Button>
             </div>
           </section>
         </div>

--- a/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
+++ b/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
@@ -77,40 +77,43 @@ const HouseholdInformationForm = props => {
           <h4 className="HouseholdInformationDetails__Form__h4">
             What Circumstances Brought Client to Open Doors?
           </h4>
-          <Form.Item name="fleeingDomV" valuePropName="checked">
-            <Checkbox disabled={disabled}>Fleeing Domestic Violence</Checkbox>
-          </Form.Item>
+          <div className="CircumstancesContainer">
+            <Form.Item name="fleeingDomV" valuePropName="checked">
+              <Checkbox disabled={disabled}>Fleeing Domestic Violence</Checkbox>
+            </Form.Item>
 
-          <Form.Item name="lackOfIncome" valuePropName="checked">
-            <Checkbox disabled={disabled}>Lack of Income</Checkbox>
-          </Form.Item>
+            <Form.Item name="lackOfIncome" valuePropName="checked">
+              <Checkbox disabled={disabled}>Lack of Income</Checkbox>
+            </Form.Item>
 
-          <Form.Item name="lostJob" valuePropName="checked">
-            <Checkbox disabled={disabled}>Lost Job</Checkbox>
-          </Form.Item>
+            <Form.Item name="lostJob" valuePropName="checked">
+              <Checkbox disabled={disabled}>Lost Job</Checkbox>
+            </Form.Item>
 
-          <Form.Item name="familyConflict" valuePropName="checked">
-            <Checkbox disabled={disabled}>Family Conflict</Checkbox>
-          </Form.Item>
+            <Form.Item name="familyConflict" valuePropName="checked">
+              <Checkbox disabled={disabled}>Family Conflict</Checkbox>
+            </Form.Item>
 
-          <Form.Item name="familyRej" valuePropName="checked">
-            <Checkbox disabled={disabled}>
-              Family Rejection/LGBTQ+ Issue
-            </Checkbox>
-          </Form.Item>
+            <Form.Item name="familyRej" valuePropName="checked">
+              <Checkbox disabled={disabled}>
+                Family Rejection/LGBTQ+ Issue
+              </Checkbox>
+            </Form.Item>
 
-          <Form.Item name="lackOfAffHous" valuePropName="checked">
-            <Checkbox disabled={disabled}>Lack of Affordable Housing</Checkbox>
-          </Form.Item>
+            <Form.Item name="lackOfAffHous" valuePropName="checked">
+              <Checkbox disabled={disabled}>
+                Lack of Affordable Housing
+              </Checkbox>
+            </Form.Item>
 
-          <Form.Item name="eviction" valuePropName="checked">
-            <Checkbox disabled={disabled}>Eviction</Checkbox>
-          </Form.Item>
+            <Form.Item name="eviction" valuePropName="checked">
+              <Checkbox disabled={disabled}>Eviction</Checkbox>
+            </Form.Item>
 
-          <Form.Item name="other" valuePropName="checked">
-            <Checkbox disabled={disabled}>Other</Checkbox>
-          </Form.Item>
-
+            <Form.Item name="other" valuePropName="checked">
+              <Checkbox disabled={disabled}>Other</Checkbox>
+            </Form.Item>
+          </div>
           <Form.Item
             name="otherText"
             label=""

--- a/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
+++ b/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
@@ -55,6 +55,7 @@ const HouseholdInformationForm = props => {
   const onFinishFailed = errorInfo => {
     console.log('Failed:', errorInfo);
   };
+
   const disableFormItem = () => {
     setDisabled(!disabled);
   };
@@ -591,31 +592,33 @@ const HouseholdInformationForm = props => {
           </Form.Item>
         </section>
         <section className="CaseSubmit">
-          {/* <Button
-            htmlType="submit"
-            disabled={disabled}
-            style={{
-              margin: '1rem',
-              color: '#CDCDCD',
-              background: '#007FD4',
-              borderColor: '#007FD4',
-            }}
-            type="primary"
-          >
-            Save Changes
-          </Button>
-          <Button
-            onClick={disableFormItem}
-            style={{
-              margin: '1rem',
-              color: '#CDCDCD',
-              background: '#007FD4',
-              borderColor: '#007FD4',
-            }}
-            type="primary"
-          >
-            Edit
-          </Button> */}
+          <div className="editButtonsContainer">
+            <Button
+              htmlType="submit"
+              disabled={disabled}
+              style={{
+                margin: '1rem',
+                color: '#CDCDCD',
+                background: '#007FD4',
+                borderWidth: '3px',
+              }}
+              type="primary"
+            >
+              SAVE
+            </Button>
+            <Button
+              onClick={disableFormItem}
+              style={{
+                margin: '1rem',
+                color: '#CDCDCD',
+                background: '#007FD4',
+                borderWidth: '3px',
+              }}
+              type="primary"
+            >
+              EDIT
+            </Button>
+          </div>
         </section>
       </Form>
     </div>

--- a/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
+++ b/src/components/common/CaseDetailsForms/HouseholdInformationForm.js
@@ -82,15 +82,27 @@ const HouseholdInformationForm = props => {
               <Checkbox disabled={disabled}>Fleeing Domestic Violence</Checkbox>
             </Form.Item>
 
-            <Form.Item name="lackOfIncome" valuePropName="checked">
+            <Form.Item
+              name="lackOfIncome"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>Lack of Income</Checkbox>
             </Form.Item>
 
-            <Form.Item name="lostJob" valuePropName="checked">
+            <Form.Item
+              name="lostJob"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>Lost Job</Checkbox>
             </Form.Item>
 
-            <Form.Item name="familyConflict" valuePropName="checked">
+            <Form.Item
+              name="familyConflict"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>Family Conflict</Checkbox>
             </Form.Item>
 
@@ -100,17 +112,29 @@ const HouseholdInformationForm = props => {
               </Checkbox>
             </Form.Item>
 
-            <Form.Item name="lackOfAffHous" valuePropName="checked">
+            <Form.Item
+              name="lackOfAffHous"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>
                 Lack of Affordable Housing
               </Checkbox>
             </Form.Item>
 
-            <Form.Item name="eviction" valuePropName="checked">
+            <Form.Item
+              name="eviction"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>Eviction</Checkbox>
             </Form.Item>
 
-            <Form.Item name="other" valuePropName="checked">
+            <Form.Item
+              name="other"
+              valuePropName="checked"
+              className="CircumstancesCheckboxes"
+            >
               <Checkbox disabled={disabled}>Other</Checkbox>
             </Form.Item>
           </div>
@@ -163,7 +187,7 @@ const HouseholdInformationForm = props => {
             rules={[{ type: 'number', message: 'Number Required' }]}
             placeholder={0}
           >
-            <InputNumber disabled={disabled} />
+            <InputNumber disabled={disabled} className="YearsMargin" />
           </Form.Item>
 
           <Form.Item
@@ -211,125 +235,132 @@ const HouseholdInformationForm = props => {
           <h4 className="HouseholdInformationDetails__Form__h4">
             How long has the Client been homeless
           </h4>
-          <Form.Item
-            name="howLongA"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                a. Living in a place not meant for human habitation
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
-
-          <Form.Item
-            name="howLongB"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                b. Emergency Shelter
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
-
-          <Form.Item
-            name="howLongC"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                c. Traditional Housing
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
-
-          <Form.Item
-            name="howLongD"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                d. Fleeing Domestic Violence
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
-
-          <Form.Item
-            name="howLongE"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                e. Unsheltered
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
-
-          <Form.Item
-            name="howLongTotal"
-            label={
-              <label
-                className={
-                  disabled === true
-                    ? 'CaseDetailsLabel__Disabled'
-                    : 'CaseDetailsLabel'
-                }
-              >
-                Total
-              </label>
-            }
-            colon={false}
-            rules={[{ type: 'number', message: 'Number Required' }]}
-            placeholder={0}
-          >
-            <InputNumber disabled={disabled} />
-          </Form.Item>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongA"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  a. Living in a place not meant for human habitation
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongB"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled HomelessTime__Margin'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  b. Emergency Shelter
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongC"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  c. Traditional Housing
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongD"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  d. Fleeing Domestic Violence
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongE"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  e. Unsheltered
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
+          <div className="HomelessTime__SingleContainer">
+            <Form.Item
+              name="howLongTotal"
+              label={
+                <label
+                  className={
+                    disabled === true
+                      ? 'CaseDetailsLabel__Disabled'
+                      : 'CaseDetailsLabel'
+                  }
+                >
+                  Total
+                </label>
+              }
+              colon={false}
+              rules={[{ type: 'number', message: 'Number Required' }]}
+              placeholder={0}
+            >
+              <InputNumber disabled={disabled} />
+            </Form.Item>
+          </div>
         </section>
 
         <section className="CPSInvolvement">
@@ -379,7 +410,7 @@ const HouseholdInformationForm = props => {
               <Radio
                 className={
                   disabled === true
-                    ? 'ant-radio-disabled + span'
+                    ? 'ant-radio-disabled + span '
                     : 'ant-radio-wrapper'
                 }
                 value={true}
@@ -560,7 +591,7 @@ const HouseholdInformationForm = props => {
           </Form.Item>
         </section>
         <section className="CaseSubmit">
-          <Button
+          {/* <Button
             htmlType="submit"
             disabled={disabled}
             style={{
@@ -584,7 +615,7 @@ const HouseholdInformationForm = props => {
             type="primary"
           >
             Edit
-          </Button>
+          </Button> */}
         </section>
       </Form>
     </div>

--- a/src/styles/css/styles.css
+++ b/src/styles/css/styles.css
@@ -66,16 +66,12 @@
   color: #ffffff;
 }
 .HouseholdInformationDetails__Form {
-  display: grid;
-  grid-template-columns: repeat(2, 1fr);
-  gap: 5px;
-  grid-auto-flow: row dense;
-  padding-top: 2rem;
-  width: 80%;
-  padding: 2rem;
-  margin: 0 12rem;
-  background: #3f3f3f;
-  color: #ffffff;
+  background: #007fd4;
+}
+.CircumstancesContainer {
+  display: flex;
+  flex-flow: row wrap;
+  width: 90%;
 }
 .HouseholdInformationDetails__Form__Circumstances {
   grid-row: 1 / span 2;
@@ -135,60 +131,74 @@
   border-color: #007fd4;
 }
 .ClientFamilyInformation__Form {
-  grid-template-columns: repeat(2, 1fr);
-  gap: 5px;
-  grid-auto-flow: row dense;
-  background: #3f3f3f;
-  color: #ffffff;
+  background: #007fd4;
 }
 .ClientFamilyInformation__Form__InitialDate {
-  margin: 0 0 2rem 62rem;
-  padding-top: 2rem;
+  color: #D2D2D7;
+  margin-left: 1.2rem;
 }
 .ClientFamilyInformation__Form__h1 {
-  color: #cdcdcd;
-  text-align: center;
+  color: #D2D2D7;
+  margin-left: 1.25rem;
 }
 .ClientFamilyInformation__Form__SectionGrid2 {
+  color: #D2D2D7;
   display: flex;
-  justify-content: space-evenly;
-}
-.ClientFamilyInformation__Form__SectionGrid3 {
-  display: flex;
+  flex-flow: row nowrap;
   justify-content: space-around;
 }
+.ClientFamilyInformation__Form__SectionGrid3 {
+  color: #D2D2D7;
+  width: 90%;
+  margin-left: 1.2rem;
+}
 .ClientFamilyInformation__Form__SmallInputs {
-  width: 7rem;
+  color: #D2D2D7;
 }
 .ClientFamilyInformation__Form__SectionGrid1 {
-  grid-row: 1 / span 2;
+  color: #D2D2D7;
+  width: 45%;
+}
+.ant-col-8 {
+  max-width: 20rem;
+  flex: 10;
+}
+.ClientFamilyInformation__Form__Inputs {
+  width: 21rem;
+}
+.CityandState__Container {
+  display: flex;
+  flex-flow: row nowrap;
+}
+.StateMargin {
+  margin-left: 2.2rem;
 }
 .ClientFamilyInformation__Form__VeteranStatus {
-  display: flex;
-  flex-direction: row-reverse;
-  margin: 0rem 11rem;
+  color: #D2D2D7;
+  margin-left: 1.25rem;
 }
 .ClientFamilyInformation__Form__FamilyMembers__Container {
-  display: flex;
-  justify-content: space-between;
-  margin: 0rem 6rem;
+  color: #D2D2D7;
 }
 .ClientFamilyInformation__Form__FamilyMembers__formItem {
-  display: flow-root;
+  color: #D2D2D7;
 }
 .ClientFamilyInformation__Form__FamilyMembers__IsPregnant {
-  display: flex;
+  color: #D2D2D7;
+  margin-left: 1.25rem;
 }
-.ClientFamilyInformation__Inputs {
-  width: 20rem;
+.pregnantFamilyMember__Container {
+  margin-left: 1.25rem;
+}
+.ClientFamilyInformation__Inputs > .ant-input {
+  background-color: #ffffff;
 }
 .ClientFamilyInformation__Inputs__ItemLabel {
-  color: #ffffff;
-  width: 25vw;
+  color: #D2D2D7;
 }
 .ClientFamilyInformation__Inputs__ItemLabel__Small {
-  color: #ffffff;
-  width: 100%;
+  color: #D2D2D7;
+  width: 10rem;
 }
 .ant-btn-primary {
   margin: 1rem;
@@ -391,7 +401,7 @@
   border-radius: 20px 0px 10px;
   color:  #cdcdcd;
 }
-.ant-input {
+.SearchBar > .ant-input {
   background-color: black;
   color: #cdcdcd;
 }

--- a/src/styles/css/styles.css
+++ b/src/styles/css/styles.css
@@ -64,14 +64,21 @@
 
 .HouseholdInformationDetails__Container {
   color: #ffffff;
+  margin-left: 1.5rem;
 }
 .HouseholdInformationDetails__Form {
   background: #007fd4;
+}
+.LengthTimeHomelessCase {
+  width: 100%;
 }
 .CircumstancesContainer {
   display: flex;
   flex-flow: row wrap;
   width: 90%;
+}
+.CircumstancesCheckboxes {
+  margin-left: 1.5rem;
 }
 .HouseholdInformationDetails__Form__Circumstances {
   grid-row: 1 / span 2;
@@ -89,14 +96,54 @@
 .HouseholdInformationDetails__Form__h4 {
   color: #cdcdcd;
 }
+.CPSInvolvement > .ant-form-item {
+  display: flex;
+  flex-flow: column nowrap;
+}
+.CPSInvolvement > .ant-form-item > .ant-col-8 {
+  max-width: 30rem;
+  text-align: left;
+}
+.HomelessTime__SingleContainer > .ant-row {
+  display: flex;
+  flex-flow: column nowrap;
+}
+.HomelessTime__SingleContainer > .ant-row > .ant-col-8 {
+  max-width: 30rem;
+}
+.HomelessTime__Margin {
+  margin-left: 0rem;
+}
+.HomelessTime__SingleContainer > .ant-row > .ant-form-item-label {
+  text-align: left;
+  width: 35rem;
+}
 .HouseholdInformationDetails__Form__p {
   color: #cdcdcd;
+}
+.HouseholdInformationDetails__Form__PrevLivSit > .ant-row {
+  display: flex;
+  flex-flow: column nowrap;
+}
+.HouseholdInformationDetails__Form__PrevLivSit > .ant-row > .ant-col-8 {
+  text-align: left;
+}
+.HouseholdInformationDetails__Form__SocialWorker > .ant-row {
+  display: flex;
+  flex-flow: column nowrap;
+}
+.HouseholdInformationDetails__Form__SocialWorker > .ant-row > .ant-col-8 {
+  text-align: left;
+  max-width: 30rem; 
 }
 .CaseDetailsLabel {
   color: #ffffff;
 }
 .CaseDetailsLabel__Disabled {
   color: #cdcdcd;
+}
+.YearsMargin {
+  margin-left: 0.95rem;
 }
 .ant-form-item-label {
   color: #ffffff;

--- a/src/styles/css/styles.css
+++ b/src/styles/css/styles.css
@@ -136,6 +136,25 @@
   text-align: left;
   max-width: 30rem; 
 }
+.editButtonsContainer {
+  display: flex;
+  flex-flow: row nowrap;
+  justify-content: flex-start;
+  align-items: center;
+}
+.editButtonsContainer > .ant-btn-primary {
+  border: 3px solid #007fd4;
+  padding-left: 52px;
+  padding-right: 52px;
+  padding-bottom: 10px;
+  padding-top: 10px;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+}
+.editButtonsContainer > .ant-btn-primary:hover {
+  border: 3px solid #cdcdcd;
+}
 .CaseDetailsLabel {
   color: #ffffff;
 }


### PR DESCRIPTION
Why? 
These forms were originally designed for a different design of the single view case details page so they needed to be redesigned to fit into our dark mode. The edit and save buttons also needed to be added so that forms were disabled on load but could be editable for changes with clients that needed to be updated by a case manager.

What was done?
I styled both forms to fit into our dark mode design of the single view case details page and added the edit and save buttons. The edit and save buttons were already built out for one form on the previous design so I restyled them and added them to the forms. The edit and save buttons did have some minor issues that I cleared up.

Loom Video: https://www.loom.com/share/c175bd1c87c545c6b0c40be376b40e95

Trello Card: https://trello.com/c/BEVIicDh/100-redesign-forms-for-the-single-case-view-case-details-page